### PR TITLE
Improve button readability in dark mode

### DIFF
--- a/src/SARgui.cpp
+++ b/src/SARgui.cpp
@@ -148,7 +148,6 @@ DlgDef::DlgDef( wxWindow* parent, wxWindowID id, const wxString& title, const wx
 
 	m_button311112121 = new wxButton( sbSizer711->GetStaticBox(), ID_RTZ1, _("Generate &RTZ"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_button311112121->SetFont( wxFont( 9, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, false, wxT("Arial") ) );
-	m_button311112121->SetBackgroundColour( wxColour( 240, 240, 240 ) );
 
 	bSizer71221->Add( m_button311112121, 0, wxALL, 5 );
 
@@ -367,7 +366,6 @@ DlgDef::DlgDef( wxWindow* parent, wxWindowID id, const wxString& title, const wx
 
 	m_button31111212 = new wxButton( sbSizer71->GetStaticBox(), ID_RTZ2, _("Generate &RTZ"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_button31111212->SetFont( wxFont( 9, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, false, wxT("Arial") ) );
-	m_button31111212->SetBackgroundColour( wxColour( 240, 240, 240 ) );
 
 	bSizer7122->Add( m_button31111212, 0, wxALL, 5 );
 
@@ -525,7 +523,6 @@ DlgDef::DlgDef( wxWindow* parent, wxWindowID id, const wxString& title, const wx
 
 	m_button31111211 = new wxButton( sbSizer713->GetStaticBox(), ID_RTZ3, _("Generate &RTZ"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_button31111211->SetFont( wxFont( 9, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, false, wxT("Arial") ) );
-	m_button31111211->SetBackgroundColour( wxColour( 240, 240, 240 ) );
 
 	bSizer7121->Add( m_button31111211, 1, wxALL, 5 );
 
@@ -693,7 +690,6 @@ DlgDef::DlgDef( wxWindow* parent, wxWindowID id, const wxString& title, const wx
 
 	m_button311112 = new wxButton( sbSizer714->GetStaticBox(), wxID_ANY, _("Generate &GPX"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_button311112->SetFont( wxFont( 9, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, false, wxT("Arial") ) );
-	m_button311112->SetBackgroundColour( wxColour( 240, 240, 240 ) );
 
 	bSizer7112->Add( m_button311112, 0, wxALL, 5 );
 
@@ -709,7 +705,6 @@ DlgDef::DlgDef( wxWindow* parent, wxWindowID id, const wxString& title, const wx
 
 	m_button3111121 = new wxButton( sbSizer714->GetStaticBox(), ID_RTZ4, _("Generate &RTZ"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_button3111121->SetFont( wxFont( 9, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, false, wxT("Arial") ) );
-	m_button3111121->SetBackgroundColour( wxColour( 240, 240, 240 ) );
 
 	bSizer712->Add( m_button3111121, 0, wxALL, 5 );
 


### PR DESCRIPTION
Button labels are not easily readable in dark mode (Ubuntu24).
Make the background consistent with the other buttons.

Before :
<img width="349" height="123" alt="image" src="https://github.com/user-attachments/assets/604f6dfa-84f1-4815-a467-aed174f26164" />
<img width="349" height="123" alt="image" src="https://github.com/user-attachments/assets/333fb6f2-e620-4ae1-b0cc-b3daccdc77c9" />


After : 
<img width="349" height="123" alt="image" src="https://github.com/user-attachments/assets/edf154f4-b674-42f0-aa95-7376157b18c4" />
<img width="349" height="123" alt="image" src="https://github.com/user-attachments/assets/d3f42639-5261-47e6-8bcd-dc97ed1d1075" />

