### PR TITLE
Clarify cursor location copy instructions

### DIFF
--- a/src/SARgui_impl.cpp
+++ b/src/SARgui_impl.cpp
@@ -1962,12 +1962,9 @@ void Dlg::OnCursorSelect(wxCommandEvent& event) {
   m_Lat1->Clear();
   m_Lon1->Clear();
 
-  wxMessageBox(
-      _("To copy the cursor location place the cursor on the chart "
-        "\n     ...and press <CTRL>+S"));
-  // wxMessageBox(_("While this button is selected, or the cursor is in the
-  // lattitude or longitude box, you can copy the cursor location with
-  // <CTRL>+S") );
+wxMessageBox( _("To copy the cursor location:\n\n" 
+  "- Right-click on the chart and choose 'Select SAR Datum Point'\n" 
+  "- Or, with the plugin window selected and the cursor on the chart, press <CTRL>+S") );
   event.Skip();
 }
 


### PR DESCRIPTION
-The message was missing the requirement that the plugin window must be open and selected for keyboard shortcuts to work.
-The message did not document the right-click method on the chart to copy the cursor location.

Before : 
<img width="538" height="92" alt="image" src="https://github.com/user-attachments/assets/bdfb8c21-caac-4803-9132-48b953ff9f91" />

After:
<img width="620" height="133" alt="image" src="https://github.com/user-attachments/assets/42f3ce95-5bc3-4757-83b7-a9c1a098bbf7" />
