### PR TITLE
Enforce minimum values and update input feedback

### DIFF
--- a/src/SARgui_impl.cpp
+++ b/src/SARgui_impl.cpp
@@ -1266,8 +1266,8 @@ void Dlg::Calculate(wxCommandEvent& event, bool write_file, int Pattern)
             speed = 5.0;
             this->m_Speed_SS->SetValue(wxString::Format("%f", speed));
           }  // search velocity
-          if (leg_distancex < 0.1) {
-            leg_distancex = 0.1;
+          if (leg_distancex < 0.5) {
+            leg_distancex = 0.5;
           }  // check for negative or small values
           if (this->m_Ncycles->GetSelection() == 1)
             two_cycles = true;  // S=1


### PR DESCRIPTION
1) Update the text input to inform the user of the value used to generate the GPX (if data input is smaller than threshold or empty)

2) Update the value to be equal to the threshold (instead of the default value of 1)

3) Update nlegs to be an int and >= 1. The default values are bigger to show the pattern without ambiguity (small nleg value can show partial pattern).

4) Update minimum leg_distancex of Sector Search to match the minimum value in the comboBox (0.5NM)